### PR TITLE
Use github site data to define URIs in templates.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,14 +1,11 @@
 #Setup ~~~
-#Follow these 3 steps to set up your site.
+#Follow these 2 steps to set up your site.
 
-#Step 1: change mozillascience to the user name you chose on GitHub:
-user: mozillascience
-
-#Step 2: give your study group a name and a short description:
+#Step 1: give your study group a name and a short description:
 title: Our Study Group
 description: "A study group."
 
-#Step 3: press the green 'Commit Changes' button at the bottom of this page.
+#Step 2: press the green 'Commit Changes' button at the bottom of this page.
 
 # That's it, your website is all set up!
 # You can see it at https://YourUserName.github.io/studyGroup/

--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -8,7 +8,7 @@
             </div>
             <div class="row">
                   <div class="col-lg-12 text-center">
-                      <a href="{{ '/studyGroup' | prepend: site.user | prepend: 'https://github.com/' }}/issues" class="btn btn-xl">Talk To Us</a>
+                      <a href="{{ site.github.issues_url }}" class="btn btn-xl">Talk To Us</a>
                   </div>
             </div>
         </div>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,14 +4,14 @@
     <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
     <meta name="viewport" content="width=device-width">
     <meta name="description" content="{{ site.description }}">
-    <link rel="canonical" href="https://{{ site.user }}.github.io/studyGroup/{{ page.url | replace:'index.html','' }}">
+    <link rel="canonical" href="{{ site.github.url }}{{ page.url | replace:'index.html','' }}">
 
 
     <!-- Custom CSS & Bootstrap Core CSS - Uses Bootswatch Flatly Theme: https://bootswatch.com/flatly/ -->
-    <link rel="stylesheet" href="https://{{ site.user }}.github.io/studyGroup/style.css">
+    <link rel="stylesheet" href="{{ site.github.url }}/style.css">
 
     <!-- Custom Fonts -->
-    <link rel="stylesheet" href="https://{{ site.user }}.github.io/studyGroup/css/font-awesome/css/font-awesome.min.css">
+    <link rel="stylesheet" href="{{ site.github.url }}/css/font-awesome/css/font-awesome.min.css">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
     <link href='https://fonts.googleapis.com/css?family=Kaushan+Script' rel='stylesheet' type='text/css'>
     <link href="https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic" rel="stylesheet" type="text/css">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,14 +4,14 @@
     <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
     <meta name="viewport" content="width=device-width">
     <meta name="description" content="{{ site.description }}">
-    <link rel="canonical" href="{{ site.github.url }}{{ page.url | replace:'index.html','' }}">
+    <link rel="canonical" href="{{ site.github.url | replace:'http:','https:' }}{{ page.url | replace:'index.html','' }}">
 
 
     <!-- Custom CSS & Bootstrap Core CSS - Uses Bootswatch Flatly Theme: https://bootswatch.com/flatly/ -->
-    <link rel="stylesheet" href="{{ site.github.url }}/style.css">
+    <link rel="stylesheet" href="{{ site.github.url | replace:'http:','https:' }}/style.css">
 
     <!-- Custom Fonts -->
-    <link rel="stylesheet" href="{{ site.github.url }}/css/font-awesome/css/font-awesome.min.css">
+    <link rel="stylesheet" href="{{ site.github.url | replace:'http:','https:' }}/css/font-awesome/css/font-awesome.min.css">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
     <link href='https://fonts.googleapis.com/css?family=Kaushan+Script' rel='stylesheet' type='text/css'>
     <link href="https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic" rel="stylesheet" type="text/css">

--- a/_includes/js.html
+++ b/_includes/js.html
@@ -1,17 +1,17 @@
  <!-- jQuery Version 1.11.0 -->
-    <script src="https://{{ site.user }}.github.io/studyGroup/js/jquery-1.11.0.js"></script>
+    <script src="{{ site.github.url }}/js/jquery-1.11.0.js"></script>
 
     <!-- Bootstrap Core JavaScript -->
-    <script src="https://{{ site.user }}.github.io/studyGroup/js/bootstrap.min.js"></script>
+    <script src="{{ site.github.url }}/js/bootstrap.min.js"></script>
 
     <!-- Plugin JavaScript -->
-    <script src="https://{{ site.user }}.github.io/studyGroup/js/jquery.easing.min.js"></script>
-    <script src="https://{{ site.user }}.github.io/studyGroup/js/classie.js"></script>
-    <script src="https://{{ site.user }}.github.io/studyGroup/js/cbpAnimatedHeader.js"></script>
+    <script src="{{ site.github.url }}/js/jquery.easing.min.js"></script>
+    <script src="{{ site.github.url }}/js/classie.js"></script>
+    <script src="{{ site.github.url }}/js/cbpAnimatedHeader.js"></script>
 
     <!-- Contact Form JavaScript -->
-    <script src="https://{{ site.user }}.github.io/studyGroup/js/jqBootstrapValidation.js"></script>
-    <script src="https://{{ site.user }}.github.io/studyGroup/js/contact_me.js"></script>
+    <script src="{{ site.github.url }}/js/jqBootstrapValidation.js"></script>
+    <script src="{{ site.github.url }}/js/contact_me.js"></script>
 
     <!-- Custom Theme JavaScript -->
-    <script src="https://{{ site.user }}.github.io/studyGroup/js/agency.js"></script>
+    <script src="{{ site.github.url }}/js/agency.js"></script>

--- a/_includes/js.html
+++ b/_includes/js.html
@@ -1,17 +1,17 @@
  <!-- jQuery Version 1.11.0 -->
-    <script src="{{ site.github.url }}/js/jquery-1.11.0.js"></script>
+    <script src="{{ site.github.url | replace:'http:','https:' }}/js/jquery-1.11.0.js"></script>
 
     <!-- Bootstrap Core JavaScript -->
-    <script src="{{ site.github.url }}/js/bootstrap.min.js"></script>
+    <script src="{{ site.github.url | replace:'http:','https:' }}/js/bootstrap.min.js"></script>
 
     <!-- Plugin JavaScript -->
-    <script src="{{ site.github.url }}/js/jquery.easing.min.js"></script>
-    <script src="{{ site.github.url }}/js/classie.js"></script>
-    <script src="{{ site.github.url }}/js/cbpAnimatedHeader.js"></script>
+    <script src="{{ site.github.url | replace:'http:','https:' }}/js/jquery.easing.min.js"></script>
+    <script src="{{ site.github.url | replace:'http:','https:' }}/js/classie.js"></script>
+    <script src="{{ site.github.url | replace:'http:','https:' }}/js/cbpAnimatedHeader.js"></script>
 
     <!-- Contact Form JavaScript -->
-    <script src="{{ site.github.url }}/js/jqBootstrapValidation.js"></script>
-    <script src="{{ site.github.url }}/js/contact_me.js"></script>
+    <script src="{{ site.github.url | replace:'http:','https:' }}/js/jqBootstrapValidation.js"></script>
+    <script src="{{ site.github.url | replace:'http:','https:' }}/js/contact_me.js"></script>
 
     <!-- Custom Theme JavaScript -->
-    <script src="{{ site.github.url }}/js/agency.js"></script>
+    <script src="{{ site.github.url | replace:'http:','https:' }}/js/agency.js"></script>

--- a/_includes/portfolio_grid.html
+++ b/_includes/portfolio_grid.html
@@ -26,11 +26,11 @@
                 {% endif %}
               {% endfor %}
               {% if isEvent == 0 %}
-                <a class='eventTitle' href="{{ '/studyGroup' | prepend: site.user | prepend: 'https://github.com/' }}/issues">Nothing yet! Propose an event here.</a>
+                <a class='eventTitle' href="{{ site.github.issues_url }}">Nothing yet! Propose an event here.</a>
               {% else %}
               <div class="row">
                     <div class="col-lg-12 text-center">
-                        <a href="{{ '/studyGroup' | prepend: site.user | prepend: 'https://github.com/' }}/issues" class="btn btn-xl eventSuggest">Suggest an Event</a>
+                        <a href="{{ site.github.issues_url }}" class="btn btn-xl eventSuggest">Suggest an Event</a>
                     </div>
               </div>
               {% endif %}
@@ -38,10 +38,10 @@
             </div>
             <div class="col-lg-12">
               <h3 class="section-heading eventInstructions">Want to be notified of our upcoming events?</h3>
-              <h3 class="section-subheading text-muted eventSubinstructions">Head over to <a href="{{ '/studyGroup' | prepend: site.user | prepend: 'https://github.com/' }}">GitHub</a> and watch our repository, like this:</h3>
+              <h3 class="section-subheading text-muted eventSubinstructions">Head over to <a href="{{ site.github.repository_url }}">GitHub</a> and watch our repository, like this:</h3>
               <figure>
                 <img src="https://help.github.com/assets/images/help/notifications/watcher_picker.gif"></img>
-                <figcaption>Look in the top right-hand corner of <a href="{{ '/studyGroup' | prepend: site.user | prepend: 'https://github.com/' }}">our repo</a>, and click 'Watching.' <br>You can undo this at any time in the same place.</figcaption>
+                <figcaption>Look in the top right-hand corner of <a href="{{ site.github.repository_url }}">our repo</a>, and click 'Watching.' <br>You can undo this at any time in the same place.</figcaption>
               </figure>
             </div>
         </div>

--- a/feed.xml
+++ b/feed.xml
@@ -3,8 +3,8 @@
   <channel>
     <title>{{ site.title | xml_escape }}</title>
     <description>{{ site.description | xml_escape }}</description>
-    <link>https://{{ site.user }}.github.io/studyGroup/</link>
-    <atom:link href="https://{{ site.user }}.github.io/studyGroup/feed.xml" rel="self" type="application/rss+xml" />
+    <link>{{ site.github.url }}</link>
+    <atom:link href="{{ site.github.url }}/feed.xml" rel="self" type="application/rss+xml" />
     <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>
@@ -13,8 +13,8 @@
         <title>{{ post.title | xml_escape }}</title>
         <description>{{ post.content | xml_escape }}</description>
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
-        <link>https://{{ site.user }}.github.io/studyGroup/{{ post.url }}</link>
-        <guid isPermaLink="true">https://{{ site.user }}.github.io/studyGroup/{{ post.url }}</guid>
+        <link>{{ site.github.url }}/{{ post.url }}</link>
+        <guid isPermaLink="true">{{ site.github.url }}/{{ post.url }}</guid>
         {% for tag in post.tags %}
         <category>{{ tag | xml_escape }}</category>
         {% endfor %}

--- a/feed.xml
+++ b/feed.xml
@@ -3,8 +3,8 @@
   <channel>
     <title>{{ site.title | xml_escape }}</title>
     <description>{{ site.description | xml_escape }}</description>
-    <link>{{ site.github.url }}</link>
-    <atom:link href="{{ site.github.url }}/feed.xml" rel="self" type="application/rss+xml" />
+    <link>{{ site.github.url | replace:'http:','https:' }}</link>
+    <atom:link href="{{ site.github.url | replace:'http:','https:' }}/feed.xml" rel="self" type="application/rss+xml" />
     <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>
@@ -13,8 +13,8 @@
         <title>{{ post.title | xml_escape }}</title>
         <description>{{ post.content | xml_escape }}</description>
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
-        <link>{{ site.github.url }}/{{ post.url }}</link>
-        <guid isPermaLink="true">{{ site.github.url }}/{{ post.url }}</guid>
+        <link>{{ site.github.url | replace:'http:','https:' }}/{{ post.url }}</link>
+        <guid isPermaLink="true">{{ site.github.url | replace:'http:','https:' }}/{{ post.url }}</guid>
         {% for tag in post.tags %}
         <category>{{ tag | xml_escape }}</category>
         {% endfor %}

--- a/index.html
+++ b/index.html
@@ -10,11 +10,11 @@ layout: default
     {% for post in site.posts %}
       <li>
         <span class="post-date">{{ post.date | date: "%b %-d, %Y" }}</span>
-        <a class="post-link" href="https://{{ site.user }}.github.io/studyGroup/{{ post.url }}">{{ post.title }}</a>
+        <a class="post-link" href="{{ site.github.url }}/{{ post.url }}">{{ post.title }}</a>
       </li>
     {% endfor %}
   </ul>
 
-  <p class="rss-subscribe">subscribe <a href="https://{{ site.user }}.github.io/studyGroup/feed.xml">via RSS</a></p>
+  <p class="rss-subscribe">subscribe <a href="{{ site.github.url }}/feed.xml">via RSS</a></p>
 
 </div>

--- a/index.html
+++ b/index.html
@@ -10,11 +10,11 @@ layout: default
     {% for post in site.posts %}
       <li>
         <span class="post-date">{{ post.date | date: "%b %-d, %Y" }}</span>
-        <a class="post-link" href="{{ site.github.url }}/{{ post.url }}">{{ post.title }}</a>
+        <a class="post-link" href="{{ site.github.url | replace:'http:','https:' }}/{{ post.url }}">{{ post.title }}</a>
       </li>
     {% endfor %}
   </ul>
 
-  <p class="rss-subscribe">subscribe <a href="{{ site.github.url }}/feed.xml">via RSS</a></p>
+  <p class="rss-subscribe">subscribe <a href="{{ site.github.url | replace:'http:','https:' }}/feed.xml">via RSS</a></p>
 
 </div>


### PR DESCRIPTION
GitHub provides `site.github` with [various entries](https://help.github.com/articles/repository-metadata-on-github-pages/) pointing to the Pages website, the repository website, etc.

One less step for setting up your own copy, because you don't need to set `site.user`. Also, you don't need to call the repo `studyGroup` if you don't want to.
