### PR TITLE
License split for theme vs content

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,7 @@
+All repository content except the Jekyll theme:
+
+Creative Commons Attribution 4.0 License, http://creativecommons.org/licenses/by/4.0/
+
 Jekyll theme by Rick Kim, https://github.com/y7kim/agency-jekyll-theme
 
 Apache License


### PR DESCRIPTION
One license applies to the content of the repo (CC-BY 4.0), while another applies to the theme template that was used (Apache 2.0). See issue #32. This adds the content license to the LICENSE file.
