### PR TITLE
Revert "Fix expansion of tags in some data variables"

### DIFF
--- a/_includes/portfolio_grid.html
+++ b/_includes/portfolio_grid.html
@@ -78,18 +78,18 @@
             <div class="col-lg-12">
             {% endif %}
               <h3 class="section-heading eventInstructions">{{site.data[site.language].notification}}</h3>
-              <h3 class="section-subheading text-muted eventSubinstructions">{{site.data[site.language].watching | liquify }}</h3>
+              <h3 class="section-subheading text-muted eventSubinstructions">{{site.data[site.language].watching}}</h3>
               <figure>
                 <img src="https://help.github.com/assets/images/help/notifications/watcher_picker.gif"></img>
-                <figcaption>{{site.data[site.language].watchingCaption | liquify}}</figcaption>
+                <figcaption>{{site.data[site.language].watchingCaption}}</figcaption>
               </figure>
             </div>
             {% if site.calendar_on %}
             <div class="col-lg-6">
               <h3 class="section-heading eventInstructions">{{site.data[site.language].calendar}}</h3>
-              <h3 class="section-subheading text-muted eventSubinstructions">{{site.data[site.language].calendarSubheading | liquify}}</h3>
-              <h3 class="section-subheading text-muted eventSubinstructions">{{site.data[site.language].googleCalendar | liquify}}</h3>
-              <h3 class="section-subheading text-muted eventSubinstructions">{{site.data[site.language].iCal | liquify}}</h3>
+              <h3 class="section-subheading text-muted eventSubinstructions">{{site.data[site.language].calendarSubheading}}</h3>
+              <h3 class="section-subheading text-muted eventSubinstructions">{{site.data[site.language].googleCalendar}}</h3>
+              <h3 class="section-subheading text-muted eventSubinstructions">{{site.data[site.language].iCal}}</h3>
             </div>
             {% endif %}
         </div>

--- a/_plugins/liquify_filter.rb
+++ b/_plugins/liquify_filter.rb
@@ -1,9 +1,0 @@
-module Jekyll
-  module LiquifyFilter
-    def liquify(input)
-      Liquid::Template.parse(input).render(@context)
-    end
-  end
-end
-
-Liquid::Template.register_filter(Jekyll::LiquifyFilter)


### PR DESCRIPTION
Reverts mozillascience/studyGroup#48

Unfortunately this looked ok locally, but didn't do the trick when deployed to GitHub - possibly another Jekyll 3-ism? cc @acabunoc @ibab.
