### PR TITLE
Fix URL tags in _data without custom ruby code

### DIFF
--- a/_data/en.yml
+++ b/_data/en.yml
@@ -24,13 +24,13 @@ leadership: How to lead a Study Group session
 pastEvents: See Our Past Events
 
 notification: Want to be notified of our upcoming events?
-watching: 'Head over to <a href="{{ site.github.repository_url }}">GitHub</a> and watch our repository, like this:'
-watchingCaption: 'Look in the top right-hand corner of <a href="{{ site.github.repository_url }}">our repo</a>, and click "Watching." <br>You can undo this at any time in the same place.'
+watching: 'Head over to <a href="%GITHUB_REPO_URL%">GitHub</a> and watch our repository, like this:'
+watchingCaption: 'Look in the top right-hand corner of <a href="%GITHUB_REPO_URL%">our repo</a>, and click "Watching." <br>You can undo this at any time in the same place.'
 
 calendar: Subscribe to our events calendar!
-calendarSubheading: 'We also invite you to follow <a href="{{ site.calendar_embed_url }}" target="_blank">our calendar</a>, where events will be posted.'
-googleCalendar: 'If you use Google calendar, you can add our calendar by pressing the "Google Calendar" button at the bottom-right of <a href="{{ site.calendar_embed_url }}" target="_blank">this page</a>.'
-iCal: 'If you use another calendar app, you can copy and paste <a href="{{ site.calendar_ical_url }}">this address</a> into any calendar product that supports the iCal format.'
+calendarSubheading: 'We also invite you to follow <a href="%CALENDAR_EMBED_URL%" target="_blank">our calendar</a>, where events will be posted.'
+googleCalendar: 'If you use Google calendar, you can add our calendar by pressing the "Google Calendar" button at the bottom-right of <a href="%CALENDAR_EMBED_URL%" target="_blank">this page</a>.'
+iCal: 'If you use another calendar app, you can copy and paste <a href="%CALENDAR_ICAL_URL%">this address</a> into any calendar product that supports the iCal format.'
 
 sayHi: Come Say Hi
 contactSubheading: 'We use GitHub to get coding help, talk about events and share files. Join us there!'

--- a/_data/pt.yml
+++ b/_data/pt.yml
@@ -24,13 +24,13 @@ leadership: Como mediar um Grupo de Estudos
 pastEvents: See Our Past Events
 
 notification: Quer ser notificado dos eventos?
-watching: 'Vá até <a href="{{ site.github.repository_url }}">GitHub</a> e acompanhe nosso respositório, assim:'
-watchingCaption: 'Olhe para o canto esquerdo superior do  <a href="{{ site.github.repository_url }}">nosso repositório</a>, e clique em  "Watching." <br>Você pode desfazer isso a qualquer momento, no mesmo lugar.'
+watching: 'Vá até <a href="%GITHUB_REPO_URL%">GitHub</a> e acompanhe nosso respositório, assim:'
+watchingCaption: 'Olhe para o canto esquerdo superior do  <a href="%GITHUB_REPO_URL%">nosso repositório</a>, e clique em  "Watching." <br>Você pode desfazer isso a qualquer momento, no mesmo lugar.'
 
 calendar: Inscreva-se em nosso Calendário de Eventos!
-calendarSubheading: 'Também o convidamos a se inscrever em <a href="{{ site.calendar_embed_url }}" target="_blank">nosso calendário</a>, no qual os eventos serão postados.'
-googleCalendar: 'Se você usa o Google Calendar, pode adicionar nosso calendário ao clicar no botão "Google Calendar" na parte direita inferior <a href="{{ site.calendar_embed_url }}" target="_blank">desta página</a>.'
-iCal: 'Se você utiliza outro aplicativo de calendário, você pode copiar e colar <a href="{{ site.calendar_ical_url }}">este endereço</a> em qualquer aplicativo de calendário que suporte o formato iCal.'
+calendarSubheading: 'Também o convidamos a se inscrever em <a href="%CALENDAR_EMBED_URL%" target="_blank">nosso calendário</a>, no qual os eventos serão postados.'
+googleCalendar: 'Se você usa o Google Calendar, pode adicionar nosso calendário ao clicar no botão "Google Calendar" na parte direita inferior <a href="%CALENDAR_EMBED_URL%" target="_blank">desta página</a>.'
+iCal: 'Se você utiliza outro aplicativo de calendário, você pode copiar e colar <a href="%CALENDAR_ICAL_URL%">este endereço</a> em qualquer aplicativo de calendário que suporte o formato iCal.'
 
 sayHi: Diga Olá!
 contactSubheading: 'Usamos o GitHub para obter ajuda com código, falar sobre eventos e compartilhar arquivos. Junte-se a nós!'

--- a/_includes/portfolio_grid.html
+++ b/_includes/portfolio_grid.html
@@ -78,18 +78,18 @@
             <div class="col-lg-12">
             {% endif %}
               <h3 class="section-heading eventInstructions">{{site.data[site.language].notification}}</h3>
-              <h3 class="section-subheading text-muted eventSubinstructions">{{site.data[site.language].watching}}</h3>
+              <h3 class="section-subheading text-muted eventSubinstructions">{{site.data[site.language].watching | replace: '%GITHUB_REPO_URL%', site.github.repository_url }}</h3>
               <figure>
                 <img src="https://help.github.com/assets/images/help/notifications/watcher_picker.gif"></img>
-                <figcaption>{{site.data[site.language].watchingCaption}}</figcaption>
+                <figcaption>{{site.data[site.language].watchingCaption | replace: '%GITHUB_REPO_URL%', site.github.repository_url}}</figcaption>
               </figure>
             </div>
             {% if site.calendar_on %}
             <div class="col-lg-6">
               <h3 class="section-heading eventInstructions">{{site.data[site.language].calendar}}</h3>
-              <h3 class="section-subheading text-muted eventSubinstructions">{{site.data[site.language].calendarSubheading}}</h3>
-              <h3 class="section-subheading text-muted eventSubinstructions">{{site.data[site.language].googleCalendar}}</h3>
-              <h3 class="section-subheading text-muted eventSubinstructions">{{site.data[site.language].iCal}}</h3>
+              <h3 class="section-subheading text-muted eventSubinstructions">{{site.data[site.language].calendarSubheading | replace: '%CALENDAR_EMBED_URL%', site.calendar_embed_url}}</h3>
+              <h3 class="section-subheading text-muted eventSubinstructions">{{site.data[site.language].googleCalendar | replace: '%CALENDAR_EMBED_URL%', site.calendar_embed_url}}</h3>
+              <h3 class="section-subheading text-muted eventSubinstructions">{{site.data[site.language].iCal | replace: '%CALENDAR_ICAL_URL%', site.calendar_ical_url}}</h3>
             </div>
             {% endif %}
         </div>


### PR DESCRIPTION
I've implemented the idea from #50 and replaced all existing
tags in the _data directory with corresponding `%VARIABLE%` tags
and put in the replacement filters.
